### PR TITLE
feat: add two different profil screen

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -31,11 +31,11 @@ export default function TabLayout() {
           paddingHorizontal: 0, // Suppression du padding horizontal des labels
         },
         tabBarItemStyle: {
-          paddingVertical: 4,
+          paddingVertical: 2,
           paddingHorizontal: 2, // Réduction du padding horizontal des items
         },
         tabBarIconStyle: {
-          marginBottom: -4, // Ajustement de l'icône pour un meilleur alignement
+          marginBottom: -2, // Ajustement de l'icône pour un meilleur alignement
         },
       }}>
       <Tabs.Screen

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -20,7 +20,7 @@ const FEATURED_ITEMS = [
 const NEARBY_TRUCKS: Truck[] = [
   {
     id: 1,
-    name: 'Le Camion Gourmand',
+    name: 'Mémé Patate',
     cuisineType: 'Cuisine française',
     distance: '0.8 km',
     rating: 4.5,

--- a/app/(tabs)/profil.tsx
+++ b/app/(tabs)/profil.tsx
@@ -1,39 +1,56 @@
-import { View, StyleSheet, ScrollView, Platform } from 'react-native';
+import { useState } from 'react';
+import { View, StyleSheet, Platform } from 'react-native';
 import { Stack } from 'expo-router';
-import { FontAwesome } from '@expo/vector-icons';
 import ScreenLayout from '../../components/ScreenLayout';
-import Text from '../../components/Text';
-import { ProfileHeader } from '../../components/profile/ProfileHeader';
-import { ProfileSection } from '../../components/profile/ProfileSection';
-import { ProfileMenuItem } from '../../components/profile/ProfileMenuItem';
-import { LogoutButton } from '../../components/profile/LogoutButton';
+import { AccountTypeSelection } from '../../components/account/AccountTypeSelection';
+import { ClientProfile } from '../../components/profile/ClientProfile';
+import { OwnerProfile } from '../../components/profile/OwnerProfile';
 import { colors } from '../../theme';
 
+type AccountType = 'client' | 'owner' | null;
+
 export default function ProfilScreen() {
+  const [accountType, setAccountType] = useState<AccountType>(null);
+
+  const handleSelectAccountType = (type: 'client' | 'owner') => {
+    setAccountType(type);
+    // TODO: Save account type to storage when auth is implemented
+  };
+
+  const handleLogout = () => {
+    setAccountType(null);
+    // TODO: Clear auth state when implemented
+  };
+
   const handleEditPress = () => {
-    // TODO: Implémenter la logique d'édition de la photo de profil
+    // TODO: Implement profile picture edit logic
     console.log('Edit profile picture');
   };
 
   const handleEditProfilePress = () => {
-    // TODO: Naviguer vers l'écran d'édition du profil
+    // TODO: Navigate to edit profile screen
     console.log('Edit profile');
   };
 
-  const handleLogout = () => {
-    // TODO: Implémenter la déconnexion
-    console.log('Logout');
-  };
-
   const handleMenuPress = (item: string) => {
-    // TODO: Gérer la navigation en fonction de l'élément du menu
+    // TODO: Handle menu item press
     console.log('Menu item pressed:', item);
   };
 
+  // Show account type selection if not selected
+  if (!accountType) {
+    return (
+      <ScreenLayout scrollable={false}>
+        <AccountTypeSelection onSelectAccountType={handleSelectAccountType} />
+      </ScreenLayout>
+    );
+  }
+
+  // Show the appropriate profile based on account type
   return (
     <ScreenLayout scrollable={false}>
       <Stack.Screen options={{ 
-        title: 'Profil',
+        title: accountType === 'client' ? 'Mon Profil' : 'Mon Food Truck',
         headerStyle: {
           backgroundColor: colors.white,
           ...Platform.select({
@@ -56,83 +73,21 @@ export default function ProfilScreen() {
         },
       }} />
       
-      <ScrollView style={styles.container}>
-        <ProfileHeader 
-          name="John Doe"
-          email="john.doe@example.com"
-          onEditPress={handleEditPress}
-          onEditProfilePress={handleEditProfilePress}
+      {accountType === 'client' ? (
+        <ClientProfile 
+          onLogout={handleLogout}
+          onEditProfile={handleEditProfilePress}
+          onEditPicture={handleEditPress}
+          onMenuPress={handleMenuPress}
         />
-        
-        {/* Section Compte */}
-        <ProfileSection title="Compte">
-          <ProfileMenuItem
-            icon={<FontAwesome name="user" size={20} color={colors.primary} />}
-            title="Informations personnelles"
-            onPress={() => handleMenuPress('Informations personnelles')}
-          />
-          
-          <ProfileMenuItem
-            icon={<FontAwesome name="lock" size={20} color={colors.primary} />}
-            title="Sécurité"
-            onPress={() => handleMenuPress('Sécurité')}
-          />
-          
-          <ProfileMenuItem
-            icon={<FontAwesome name="bell" size={20} color={colors.primary} />}
-            title="Notifications"
-            onPress={() => handleMenuPress('Notifications')}
-          />
-        </ProfileSection>
-        
-        {/* Section Préférences */}
-        <ProfileSection title="Préférences">
-          <ProfileMenuItem
-            icon={<FontAwesome name="language" size={20} color={colors.primary} />}
-            title="Langue"
-            rightContent={
-              <Text variant="body" color="gray">Français</Text>
-            }
-            onPress={() => handleMenuPress('Langue')}
-          />
-          
-          <ProfileMenuItem
-            icon={<FontAwesome name="moon-o" size={20} color={colors.primary} />}
-            title="Thème"
-            rightContent={
-              <Text variant="body" color="gray">Système</Text>
-            }
-            onPress={() => handleMenuPress('Thème')}
-          />
-        </ProfileSection>
-        
-        {/* Section Aide & Support */}
-        <ProfileSection title="Aide & Support">
-          <ProfileMenuItem
-            icon={<FontAwesome name="question-circle" size={20} color={colors.primary} />}
-            title="Centre d'aide"
-            onPress={() => handleMenuPress('Centre d\'aide')}
-          />
-          
-          <ProfileMenuItem
-            icon={<FontAwesome name="envelope" size={20} color={colors.primary} />}
-            title="Nous contacter"
-            onPress={() => handleMenuPress('Nous contacter')}
-          />
-          
-          <ProfileMenuItem
-            icon={<FontAwesome name="info-circle" size={20} color={colors.primary} />}
-            title="À propos"
-            onPress={() => handleMenuPress('À propos')}
-          />
-        </ProfileSection>
-        
-        {/* Bouton de déconnexion */}
-        <LogoutButton 
-          onPress={handleLogout}
-          version="1.0.0"
+      ) : (
+        <OwnerProfile 
+          onLogout={handleLogout}
+          onEditProfile={handleEditProfilePress}
+          onEditPicture={handleEditPress}
+          onMenuPress={handleMenuPress}
         />
-      </ScrollView>
+      )}
     </ScreenLayout>
   );
 }

--- a/components/account/AccountTypeSelection.tsx
+++ b/components/account/AccountTypeSelection.tsx
@@ -107,7 +107,7 @@ const styles = StyleSheet.create({
     width: 64,
     height: 64,
     borderRadius: 32,
-    backgroundColor: 'rgba(59, 130, 246, 0.1)',
+    backgroundColor: `${colors.primary}1A`, // 10% opacity of primary color
     justifyContent: 'center',
     alignItems: 'center',
     marginBottom: 16,

--- a/components/account/AccountTypeSelection.tsx
+++ b/components/account/AccountTypeSelection.tsx
@@ -1,0 +1,125 @@
+import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import { Stack } from 'expo-router';
+import { FontAwesome5 } from '@expo/vector-icons';
+import { colors } from '../../theme';
+import Text from '../Text';
+import ScreenLayout from '../ScreenLayout';
+
+type AccountTypeSelectionProps = {
+  onSelectAccountType: (type: 'client' | 'owner') => void;
+};
+
+export function AccountTypeSelection({ onSelectAccountType }: AccountTypeSelectionProps) {
+  return (
+    <ScreenLayout scrollable={false}>
+      <Stack.Screen options={{ 
+        title: 'Choisissez un type de compte',
+        headerShown: false
+      }} />
+      
+      <View style={styles.container}>
+        <Text variant="h2" style={styles.title}>
+          Bienvenue sur TruckFinder
+        </Text>
+        <Text style={styles.subtitle}>
+          Choisissez votre type de compte pour continuer
+        </Text>
+        
+        <View style={styles.cardsContainer}>
+          {/* Client Card */}
+          <TouchableOpacity 
+            style={[styles.card, styles.clientCard]}
+            onPress={() => onSelectAccountType('client')}
+          >
+            <View style={styles.cardIconContainer}>
+              <FontAwesome5 name="user" size={32} color={colors.primary} />
+            </View>
+            <Text variant="h3" style={styles.cardTitle}>
+              Client
+            </Text>
+            <Text style={styles.cardDescription}>
+              Je veux découvrir et commander dans des food trucks
+            </Text>
+          </TouchableOpacity>
+          
+          {/* Owner Card */}
+          <TouchableOpacity 
+            style={[styles.card, styles.ownerCard]}
+            onPress={() => onSelectAccountType('owner')}
+          >
+            <View style={styles.cardIconContainer}>
+              <FontAwesome5 name="truck" size={32} color={colors.primary} />
+            </View>
+            <Text variant="h3" style={styles.cardTitle}>
+              Propriétaire
+            </Text>
+            <Text style={styles.cardDescription}>
+              Je gère un food truck et je veux développer mon activité
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </ScreenLayout>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    justifyContent: 'center',
+    backgroundColor: colors.background,
+  },
+  title: {
+    textAlign: 'center',
+    marginBottom: 8,
+    color: colors.dark,
+  },
+  subtitle: {
+    textAlign: 'center',
+    marginBottom: 40,
+    color: colors.gray,
+    fontSize: 16,
+  },
+  cardsContainer: {
+    gap: 20,
+  },
+  card: {
+    backgroundColor: colors.white,
+    borderRadius: 12,
+    padding: 24,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 8,
+    elevation: 3,
+  },
+  clientCard: {
+    borderTopWidth: 4,
+    borderTopColor: colors.primary,
+  },
+  ownerCard: {
+    borderTopWidth: 4,
+    borderTopColor: colors.secondary,
+  },
+  cardIconContainer: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    backgroundColor: 'rgba(59, 130, 246, 0.1)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  cardTitle: {
+    marginBottom: 8,
+    color: colors.dark,
+  },
+  cardDescription: {
+    textAlign: 'center',
+    color: colors.gray,
+    fontSize: 14,
+    lineHeight: 20,
+  },
+});

--- a/components/home/FeaturedSection.tsx
+++ b/components/home/FeaturedSection.tsx
@@ -31,13 +31,19 @@ export const FeaturedSection: React.FC<FeaturedSectionProps> = ({
         {title}
       </Text>
       
-      <TouchableOpacity 
-        style={styles.featuredCard}
-        onPress={() => onItemPress?.(items[0])}
-        activeOpacity={0.9}
-      >
-        <Text>{items[0].description}</Text>
-      </TouchableOpacity>
+      <View style={styles.featuredCard}>
+        <View style={styles.cardContent}>
+          <Text variant="h3" style={styles.cardTitle}>{items[0].title}</Text>
+          <Text style={styles.cardDescription}>{items[0].description}</Text>
+          <TouchableOpacity 
+            style={styles.seeMoreButton}
+            onPress={() => onItemPress?.(items[0])}
+            activeOpacity={0.8}
+          >
+            <Text style={styles.seeMoreText}>Voir plus</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
     </View>
   );
 };
@@ -53,11 +59,39 @@ const styles = StyleSheet.create({
     color: colors.dark,
   },
   featuredCard: {
-    backgroundColor: colors.lightGray,
+    backgroundColor: colors.white,
     borderRadius: 12,
     padding: spacing.lg,
-    alignItems: 'center',
-    justifyContent: 'center',
-    height: 180,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 8,
+    elevation: 3,
+    borderWidth: 1,
+    borderColor: colors.lightGray,
+  },
+  cardContent: {
+    alignItems: 'flex-start',
+  },
+  cardTitle: {
+    marginBottom: spacing.sm,
+    color: colors.dark,
+    fontWeight: '600',
+  },
+  cardDescription: {
+    marginBottom: spacing.md,
+    color: colors.darkGray,
+    lineHeight: 20,
+  },
+  seeMoreButton: {
+    backgroundColor: colors.primary,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderRadius: 20,
+  },
+  seeMoreText: {
+    color: colors.white,
+    fontWeight: '600',
+    fontSize: 14,
   },
 });

--- a/components/home/NearbySection.tsx
+++ b/components/home/NearbySection.tsx
@@ -41,7 +41,22 @@ export const NearbySection: React.FC<NearbySectionProps> = ({
             onPress={() => onTruckPress?.(truck)}
             activeOpacity={0.9}
           >
-            <View style={styles.nearbyItemContent} />
+            <View style={styles.nearbyItemContent}>
+              <Text variant="body" style={styles.truckName} numberOfLines={1}>
+                {truck.name}
+              </Text>
+              <Text variant="caption" style={styles.truckCuisine} numberOfLines={1}>
+                {truck.cuisineType}
+              </Text>
+              <View style={styles.truckInfo}>
+                <Text variant="caption" style={styles.truckDistance}>
+                  {truck.distance}
+                </Text>
+                <Text variant="caption" style={styles.truckRating}>
+                  ★ {truck.rating}
+                </Text>
+              </View>
+            </View>
           </TouchableOpacity>
         ))}
       </ScrollView>
@@ -70,12 +85,37 @@ const styles = StyleSheet.create({
   nearbyItem: {
     width: 200,
     height: 120,
-    backgroundColor: colors.lightGray,
+    backgroundColor: colors.white,
     borderRadius: 12,
     marginRight: spacing.md,
     overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: colors.lightGray,
+    padding: spacing.md,
   },
   nearbyItemContent: {
     flex: 1,
+    justifyContent: 'space-between',
+  },
+  truckName: {
+    fontWeight: '600',
+    color: colors.dark,
+    marginBottom: spacing.xs,
+  },
+  truckCuisine: {
+    color: colors.gray,
+    marginBottom: spacing.sm,
+  },
+  truckInfo: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  truckDistance: {
+    color: colors.gray,
+  },
+  truckRating: {
+    color: colors.primary,
+    fontWeight: '600',
   },
 });

--- a/components/profile/ClientProfile.tsx
+++ b/components/profile/ClientProfile.tsx
@@ -1,0 +1,118 @@
+import { View, StyleSheet, ScrollView } from 'react-native';
+import { FontAwesome } from '@expo/vector-icons';
+import { ProfileHeader } from './ProfileHeader';
+import { ProfileSection } from './ProfileSection';
+import { ProfileMenuItem } from './ProfileMenuItem';
+import { LogoutButton } from './LogoutButton';
+import Text from '../Text';
+import { colors } from '../../theme';
+
+type ClientProfileProps = {
+  onLogout: () => void;
+  onEditProfile: () => void;
+  onEditPicture: () => void;
+  onMenuPress: (item: string) => void;
+};
+
+export function ClientProfile({
+  onLogout,
+  onEditProfile,
+  onEditPicture,
+  onMenuPress,
+}: ClientProfileProps) {
+  return (
+    <ScrollView style={styles.container}>
+      <ProfileHeader 
+        name="John Doe"
+        email="john.doe@example.com"
+        onEditPress={onEditPicture}
+        onEditProfilePress={onEditProfile}
+      />
+      
+      {/* Section Commandes */}
+      <ProfileSection title="Mes Commandes">
+        <ProfileMenuItem
+          icon={<FontAwesome name="history" size={20} color={colors.primary} />}
+          title="Historique des commandes"
+          onPress={() => onMenuPress('Historique des commandes')}
+        />
+        
+        <ProfileMenuItem
+          icon={<FontAwesome name="heart" size={20} color={colors.primary} />}
+          title="Favoris"
+          onPress={() => onMenuPress('Favoris')}
+        />
+      </ProfileSection>
+      
+      {/* Section Compte */}
+      <ProfileSection title="Compte">
+        <ProfileMenuItem
+          icon={<FontAwesome name="user" size={20} color={colors.primary} />}
+          title="Informations personnelles"
+          onPress={() => onMenuPress('Informations personnelles')}
+        />
+        
+        <ProfileMenuItem
+          icon={<FontAwesome name="lock" size={20} color={colors.primary} />}
+          title="Sécurité"
+          onPress={() => onMenuPress('Sécurité')}
+        />
+        
+        <ProfileMenuItem
+          icon={<FontAwesome name="bell" size={20} color={colors.primary} />}
+          title="Notifications"
+          onPress={() => onMenuPress('Notifications')}
+        />
+      </ProfileSection>
+      
+      {/* Section Préférences */}
+      <ProfileSection title="Préférences">
+        <ProfileMenuItem
+          icon={<FontAwesome name="language" size={20} color={colors.primary} />}
+          title="Langue"
+          rightContent={
+            <Text variant="body" color="gray">Français</Text>
+          }
+          onPress={() => onMenuPress('Langue')}
+        />
+        
+        <ProfileMenuItem
+          icon={<FontAwesome name="moon-o" size={20} color={colors.primary} />}
+          title="Thème"
+          rightContent={
+            <Text variant="body" color="gray">Système</Text>
+          }
+          onPress={() => onMenuPress('Thème')}
+        />
+      </ProfileSection>
+      
+      {/* Section Aide & Support */}
+      <ProfileSection title="Aide & Support">
+        <ProfileMenuItem
+          icon={<FontAwesome name="question-circle" size={20} color={colors.primary} />}
+          title="Centre d'aide"
+          onPress={() => onMenuPress('Centre d\'aide')}
+        />
+        
+        <ProfileMenuItem
+          icon={<FontAwesome name="envelope" size={20} color={colors.primary} />}
+          title="Nous contacter"
+          onPress={() => onMenuPress('Nous contacter')}
+        />
+      </ProfileSection>
+      
+      {/* Bouton de déconnexion */}
+      <LogoutButton 
+        onPress={onLogout}
+        version="1.0.0"
+      />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+});

--- a/components/profile/OwnerProfile.tsx
+++ b/components/profile/OwnerProfile.tsx
@@ -1,0 +1,125 @@
+import { View, StyleSheet, ScrollView } from 'react-native';
+import { FontAwesome, FontAwesome5 } from '@expo/vector-icons';
+import { ProfileHeader } from './ProfileHeader';
+import { ProfileSection } from './ProfileSection';
+import { ProfileMenuItem } from './ProfileMenuItem';
+import { LogoutButton } from './LogoutButton';
+import Text from '../Text';
+import { colors } from '../../theme';
+
+type OwnerProfileProps = {
+  onLogout: () => void;
+  onEditProfile: () => void;
+  onEditPicture: () => void;
+  onMenuPress: (item: string) => void;
+};
+
+export function OwnerProfile({
+  onLogout,
+  onEditProfile,
+  onEditPicture,
+  onMenuPress,
+}: OwnerProfileProps) {
+  return (
+    <ScrollView style={styles.container}>
+      <ProfileHeader 
+        name="Food Truck du Chef"
+        email="contact@foodtruckduchef.com"
+        onEditPress={onEditPicture}
+        onEditProfilePress={onEditProfile}
+      />
+      
+      {/* Section Business */}
+      <ProfileSection title="Mon Business">
+        <ProfileMenuItem
+          icon={<FontAwesome5 name="chart-line" size={20} color={colors.primary} />}
+          title="Tableau de bord"
+          onPress={() => onMenuPress('Tableau de bord')}
+        />
+        
+        <ProfileMenuItem
+          icon={<FontAwesome5 name="utensils" size={20} color={colors.primary} />}
+          title="Gestion du menu"
+          onPress={() => onMenuPress('Gestion du menu')}
+        />
+        
+        <ProfileMenuItem
+          icon={<FontAwesome5 name="calendar-alt" size={20} color={colors.primary} />}
+          title="Calendrier & Emplacements"
+          onPress={() => onMenuPress('Calendrier')}
+        />
+        
+        <ProfileMenuItem
+          icon={<FontAwesome5 name="receipt" size={20} color={colors.primary} />}
+          title="Commandes"
+          badge="5 nouvelles"
+          onPress={() => onMenuPress('Commandes')}
+        />
+      </ProfileSection>
+      
+      {/* Section Compte */}
+      <ProfileSection title="Compte">
+        <ProfileMenuItem
+          icon={<FontAwesome5 name="store" size={20} color={colors.primary} />}
+          title="Informations du food truck"
+          onPress={() => onMenuPress('Informations du food truck')}
+        />
+        
+        <ProfileMenuItem
+          icon={<FontAwesome name="user" size={20} color={colors.primary} />}
+          title="Propriétaire"
+          onPress={() => onMenuPress('Propriétaire')}
+        />
+        
+        <ProfileMenuItem
+          icon={<FontAwesome name="lock" size={20} color={colors.primary} />}
+          title="Sécurité"
+          onPress={() => onMenuPress('Sécurité')}
+        />
+      </ProfileSection>
+      
+      {/* Section Statistiques */}
+      <ProfileSection title="Statistiques">
+        <ProfileMenuItem
+          icon={<FontAwesome5 name="chart-pie" size={20} color={colors.primary} />}
+          title="Vue d'ensemble"
+          onPress={() => onMenuPress('Statistiques')}
+        />
+        
+        <ProfileMenuItem
+          icon={<FontAwesome5 name="money-bill-wave" size={20} color={colors.primary} />}
+          title="Revenus"
+          onPress={() => onMenuPress('Revenus')}
+        />
+      </ProfileSection>
+      
+      {/* Section Support */}
+      <ProfileSection title="Support">
+        <ProfileMenuItem
+          icon={<FontAwesome name="question-circle" size={20} color={colors.primary} />}
+          title="Aide & Support"
+          onPress={() => onMenuPress('Aide & Support')}
+        />
+        
+        <ProfileMenuItem
+          icon={<FontAwesome name="cog" size={20} color={colors.primary} />}
+          title="Paramètres avancés"
+          onPress={() => onMenuPress('Paramètres avancés')}
+        />
+      </ProfileSection>
+      
+      {/* Bouton de déconnexion */}
+      <LogoutButton 
+        onPress={onLogout}
+        version="1.0.0"
+      />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+});

--- a/components/profile/ProfileMenuItem.tsx
+++ b/components/profile/ProfileMenuItem.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { View, StyleSheet, TouchableOpacity } from 'react-native';
 import { FontAwesome } from '@expo/vector-icons';
 import Text from '../Text';
@@ -9,6 +9,7 @@ interface ProfileMenuItemProps {
   title: string;
   rightContent?: React.ReactNode;
   showArrow?: boolean;
+  badge?: string | number;
   onPress?: () => void;
 }
 
@@ -17,6 +18,7 @@ export const ProfileMenuItem: React.FC<ProfileMenuItemProps> = ({
   title,
   rightContent,
   showArrow = true,
+  badge,
   onPress,
 }) => {
   return (
@@ -35,6 +37,13 @@ export const ProfileMenuItem: React.FC<ProfileMenuItemProps> = ({
       </View>
       
       <View style={styles.menuRight}>
+        {badge && (
+          <View style={styles.badge}>
+            <Text variant="caption" style={styles.badgeText}>
+              {badge}
+            </Text>
+          </View>
+        )}
         {rightContent}
         {showArrow && (
           <FontAwesome 
@@ -78,5 +87,20 @@ const styles = StyleSheet.create({
   },
   menuArrow: {
     marginLeft: spacing.sm,
+  },
+  badge: {
+    backgroundColor: colors.primary,
+    borderRadius: 10,
+    minWidth: 20,
+    height: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: spacing.xs,
+    marginRight: spacing.sm,
+  },
+  badgeText: {
+    color: colors.white,
+    fontSize: 12,
+    fontWeight: 'bold',
   },
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced account type selection on the profile screen, allowing users to choose between "client" and "owner" profiles.
  * Added dedicated profile interfaces for clients and owners, each with tailored sections and menu items.
  * Implemented a badge indicator for menu items in profile sections.

* **Enhancements**
  * Improved the Nearby section by displaying detailed truck information, including name, cuisine, distance, and rating.
  * Updated the first food truck name in the nearby list.
  * Redesigned the featured section with a card layout and a dedicated "Voir plus" button for better user interaction.

* **Style**
  * Adjusted tab bar spacing and icon alignment for a cleaner appearance.

* **Refactor**
  * Simplified and modularized the profile screen layout for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->